### PR TITLE
Dont filter unimported qualified

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -575,10 +575,16 @@ If supplied, GLOBS are the source file globs for this project."
             (`1 (cdr (assoc 'module (aref completions 0))))
             (_ (completing-read "Which Module: "
                                 (seq-map (lambda (x) (let-alist x .module)) completions))))))
-    (unless (string= (psc-ide-qualifier-for-module module) qualifier)
-      (save-buffer)
-      (psc-ide-send-sync (psc-ide-command-add-qualified-import module qualifier))
-      (revert-buffer nil t))))
+    (psc-ide-add-import-qualified-impl-write-buffer module qualifier)))
+
+(defun psc-ide-add-import-qualified-impl-write-buffer (module qualifier)
+  "finish the qualified import process for a specified module and qualifier.
+  if `psc-ide-qualifier-for-module` comes back with the qualifier exsting, do nothing.
+"
+  (unless (string= (psc-ide-qualifier-for-module module) qualifier)
+    (save-buffer)
+    (psc-ide-send-sync (psc-ide-command-add-qualified-import module qualifier))
+    (revert-buffer nil t)))
 
 (defun psc-ide-company-fetcher (_ &optional manual)
   "Create an asynchronous company fetcher.


### PR DESCRIPTION
From #147, where I want to be able to get suggestions for an "unqualified" import (a qualified import that has not yet been imported), then have it done.

The major lacking thing is that there's a global state for keeping track of if unqualified import was being handled in the completion. I'd like to know if there are actually good ways to do this with company.