### PR TITLE
Smarter server offline detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2019-03-03 Automatically turn off completion, type on hover, and flycheck if server isn't running
+
+- To figure out if the server isn't running we remember if the last
+  connection attempt failed. By triggering an explicit request (asking
+  for a type explicitly/go-to-definition/manual autocompletion) you
+  can force a re-check for an externally started server. Running
+  `psc-ide-server-start` also resets the behaviour.
+
 ## 2019-01-22 Detect and handle spago projects
 
 ## 2019-01-15 No longer uses shell-expansion when calling the psc-package command

--- a/psc-ide-flycheck.el
+++ b/psc-ide-flycheck.el
@@ -131,7 +131,7 @@ CALLBACK is the status callback passed by flycheck."
 
 (defun psc-ide-flycheck-available-p ()
   "Return non-nil if we can use the psc-ide flycheck backend in this buffer."
-  (and psc-ide-mode (psc-ide-server-running-p)))
+  (and psc-ide-mode psc-ide-server-running))
 
 (flycheck-define-generic-checker 'psc-ide
   "A purescript syntax checker using the `psc-ide' interface."

--- a/psc-ide-flycheck.el
+++ b/psc-ide-flycheck.el
@@ -131,7 +131,7 @@ CALLBACK is the status callback passed by flycheck."
 
 (defun psc-ide-flycheck-available-p ()
   "Return non-nil if we can use the psc-ide flycheck backend in this buffer."
-  (and psc-ide-mode psc-ide-server-running))
+  (and psc-ide-mode (psc-ide-server-running-p)))
 
 (flycheck-define-generic-checker 'psc-ide
   "A purescript syntax checker using the `psc-ide' interface."

--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -30,8 +30,10 @@
                 (setq timed-out t))))
 
           (delete-process proc)
+          (setq-local psc-ide-server-running t)
           (json-read-from-string (-first-item (s-lines (buffer-string)))))
       (error
+       (setq-local psc-ide-server-running nil)
        (error
         (s-join " "
                 '("It seems like the server is not running. You can"
@@ -52,6 +54,7 @@
       (error
        (progn
          (kill-buffer buffer)
+         (setq-local psc-ide-server-running nil)
          (error
           (s-join " "
                   '("It seems like the server is not running. You can"
@@ -68,6 +71,7 @@ Evaluates the CALLBACK in the context of the CURRENT buffer that initiated call 
         (kill-buffer buffer)
         (when (buffer-live-p current)
           (with-current-buffer current
+            (setq-local psc-ide-server-running t)
             (funcall callback parsed))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -40,7 +40,7 @@
 ;;;###autoload
 (define-minor-mode psc-ide-mode
   "psc-ide-mode definition"
-  :lighter (:eval (concat " psc-ide" (unless psc-ide-server-running "!")))
+  :lighter (:eval (concat " psc-ide" (unless (psc-ide-server-running-p) "!")))
   :keymap (let ((map (make-sparse-keymap)))
             (define-key map (kbd "C-c C-s") 'psc-ide-server-start)
             (define-key map (kbd "C-c C-q") 'psc-ide-server-quit)
@@ -195,7 +195,7 @@ COMMAND, ARG and IGNORED correspond to the standard company backend API."
              ;; Don't complete as the user types when we think the
              ;; server isn't available, but do try if they explicitly
              ;; requested the completion
-             (or company--manual-action psc-ide-server-running))
+             (or company--manual-action (psc-ide-server-running-p)))
     (cl-case command
       (interactive (company-begin-backend 'company-psc-ide-backend))
 
@@ -404,7 +404,7 @@ ERROR-TYPE is either \"error\" or \"warning\" and gets displayed with the RAW-ME
 
 (defun psc-ide-show-type-eldoc ()
   "Show type of the symbol under cursor, but be quiet about failures."
-  (when psc-ide-server-running
+  (when (psc-ide-server-running-p)
     (psc-ide-show-type-impl (psc-ide-ident-at-point))))
 
 (defun psc-ide-case-split-impl (type)
@@ -472,6 +472,10 @@ STRING is for use when the search used was with `string-match'."
          "server"
          psc-ide-server-buffer-name
          (psc-ide-server-command dir-name globs)))
+
+(defun psc-ide-server-running-p ()
+  "Return non-nil if we're assuming the server is running."
+  psc-ide-server-running)
 
 (defun psc-ide-server-command (dir-name &optional globs)
   "Build a shell command to start 'purs ide' in directory DIR-NAME.


### PR DESCRIPTION
There are various workflows that don't start the ide server from within Emacs, so I'd like to support those too. For example:

- A coworker starts his ide server from an NPM script
- I know people share an ide instance with a running `pscid` process
- Myself hacking on the ide server

I've wanted to do this for a long time, so thank you @purcell (if you could take a look at this change that would be great!) for finally getting me to do it :D I've just got one request, please add a short note to `CHANGELOG.md` if you make a change that changes the plugins behaviour in a visible way.