### PR TITLE
Rebuild codegen

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,6 +38,22 @@
    (setq psc-ide-use-npm-bin t)
    #+END_SRC
 
+   If you would like to use a custom codegen target for your rebuild. (default
+   is "js")
+
+   There is a `psc-ide-codegen` option that can be set globally in your user config:
+
+   #+BEGIN_SRC elisp
+   (setq psc-ide-codegen '("erl"))
+   #+END_SRC
+
+   or in specific files by addind this to the top of file:
+
+   #+BEGIN_SRC elisp
+   -- -*- psc-ide-codegen: ("erl") -*-
+   #+END_SRC
+
+
 ** Usage
 
 *** Start the Server ~C-c C-s~

--- a/README.org
+++ b/README.org
@@ -44,13 +44,13 @@
    There is a `psc-ide-codegen` option that can be set globally in your user config:
 
    #+BEGIN_SRC elisp
-   (setq psc-ide-codegen '("erl"))
+   (setq psc-ide-codegen '("corefn"))
    #+END_SRC
 
    or in specific files by addind this to the top of file:
 
    #+BEGIN_SRC elisp
-   -- -*- psc-ide-codegen: ("erl") -*-
+   -- -*- psc-ide-codegen: ("corefn") -*-
    #+END_SRC
 
 

--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -143,7 +143,9 @@ Evaluates the CALLBACK in the context of the CURRENT buffer that initiated call 
 (defun psc-ide-command-rebuild (&optional filepath actualFile)
   (json-encode
    (list :command "rebuild"
-         :params (append (list :file (or filepath (buffer-file-name)))
+         :params (append (list
+                          :codegen psc-ide-codegen
+                          :file (or filepath (buffer-file-name)))
                          (when actualFile (list :actualFile actualFile))))))
 
 (defun psc-ide-command-list-imports (&optional filepath)

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -164,12 +164,12 @@ files."
   :type '(repeat string))
 
 (defcustom psc-ide-codegen
-  '("js" "corefn")
+  '("js")
   "Codegen used for compilation.
 Specified the codegen targets the rebuild should produce.
 Uses the same target names as the command line compiler. Defaults to just JS output"
   :group 'psc-ide
-  :type '(choice string (repeat string)))
+  :type '(repeat string))
 
 (defconst psc-ide-import-regex
   (rx (and line-start "import" (1+ space)

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -164,7 +164,7 @@ files."
   :type '(repeat string))
 
 (defcustom psc-ide-codegen
-  '("js")
+  '("corefn")
   "Codegen used for compilation.
 Specified the codegen targets the rebuild should produce.
 Uses the same target names as the command line compiler. Defaults to just JS output"

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -163,6 +163,14 @@ files."
   :group 'psc-ide
   :type '(repeat string))
 
+(defcustom psc-ide-codegen
+  '("js" "corefn")
+  "Codegen used for compilation.
+Specified the codegen targets the rebuild should produce.
+Uses the same target names as the command line compiler. Defaults to just JS output"
+  :group 'psc-ide
+  :type '(choice string (repeat string)))
+
 (defconst psc-ide-import-regex
   (rx (and line-start "import" (1+ space)
            (group (and (1+ (any word "."))))

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -164,7 +164,7 @@ files."
   :type '(repeat string))
 
 (defcustom psc-ide-codegen
-  '("corefn")
+  '("js")
   "Codegen used for compilation.
 Specified the codegen targets the rebuild should produce.
 Uses the same target names as the command line compiler. Defaults to just JS output"


### PR DESCRIPTION
## Description:
Add custom codegen options to "rebuilds" and default to ["js"].
Think the code is right but I haven't figured out the workflow of testing it in a project.

## Issue it solves:
I'm trying to use purerl backend but I get the error:
The foreign module implementation for module X is missing.