### PR TITLE
allow setting source globs with PURS_IDE_SOURCES

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -245,6 +245,7 @@ COMMAND, ARG and IGNORED correspond to the standard company backend API."
    psc-ide-source-globs
    (pcase (getenv "PURS_IDE_SOURCES")
      ((and (pred stringp) globs)
+      (message "Using source globs from PURS_IDE_SOURCES")
       (split-string globs "[\r\n\s]+" t))
      (_ (psc-ide-server-use-package-manager-globs)))))
 


### PR DESCRIPTION
with direnv and other tools like such, you can just set env vars per project for what you actually want to work with.

in my case, i either do not use a purescript package manager or i use psc-package. when i do not use a purescript package manager, i have the packages provided in other ways such that i know where my dependencies are and can set them to PURS_IDE_SOURCES.