### PR TITLE
Suggests the project root according to Emacs's new `project` package

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -782,9 +782,12 @@ on whether WARN is true.  Optionally EXPANDs type synonyms."
 
 (defun psc-ide-suggest-project-dir ()
   "Suggest a project directory to start the ide server in."
-  (if (and (fboundp 'projectile-project-root) (projectile-project-p))
-      (projectile-project-root)
-    default-directory))
+  (cond
+   ((and (fboundp 'projectile-project-root) (projectile-project-p))
+    (projectile-project-root))
+   ((fboundp 'project-root)
+     (project-root (project-current)))
+   (t default-directory)))
 
 (defun psc-ide-string-fontified (string)
   "Take a STRING and return it with syntax highlighting."


### PR DESCRIPTION
When projectile isn't installed we used to just fall back to default-directory. We now also try Emacs's built-in project mode before default-directory. I'll leave this open for a day or two before merging, in case someone wants to comment.