### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -10,7 +10,7 @@
 ;;            Brian Sermons
 ;; Homepage : https://github.com/purescript-emacs/psc-ide-emacs
 ;; Version  : 0.1.0
-;; Package-Requires: ((emacs "25") (dash "2.13.0") (dash-functional "1.2.0") (company "0.8.7") (s "1.10.0") (flycheck "0.24") (let-alist "1.0.4") (seq "1.11"))
+;; Package-Requires: ((emacs "25") (dash "2.18.0") (company "0.8.7") (s "1.10.0") (flycheck "0.24") (let-alist "1.0.4") (seq "1.11"))
 ;; Keywords : languages
 
 ;;; Commentary:
@@ -27,7 +27,6 @@
 (require 'company)
 (require 'cl-lib)
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 (require 'xref)
 (require 'psc-ide-backported)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218